### PR TITLE
Introduced versioning as required in latest HA update

### DIFF
--- a/custom_components/philips_airpurifier/manifest.json
+++ b/custom_components/philips_airpurifier/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "philips_airpurifier",
   "name": "Philips AirPurifier (with CoAP)",
-  "version": "2021-03-07",
+  "version": "v2021-03-07",
   "documentation": "https://github.com/betaboon/philips-airpurifier",
   "dependencies": [],
   "codeowners": ["@betaboon"],

--- a/custom_components/philips_airpurifier/manifest.json
+++ b/custom_components/philips_airpurifier/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "philips_airpurifier",
   "name": "Philips AirPurifier (with CoAP)",
-  "version": "v2021.03.07",
+  "version": "0.3.7",
   "documentation": "https://github.com/betaboon/philips-airpurifier",
   "dependencies": [],
   "codeowners": ["@betaboon"],

--- a/custom_components/philips_airpurifier/manifest.json
+++ b/custom_components/philips_airpurifier/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "philips_airpurifier",
   "name": "Philips AirPurifier (with CoAP)",
-  "version": "v2021-03-07",
+  "version": "v2021.03.07",
   "documentation": "https://github.com/betaboon/philips-airpurifier",
   "dependencies": [],
   "codeowners": ["@betaboon"],

--- a/custom_components/philips_airpurifier/manifest.json
+++ b/custom_components/philips_airpurifier/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "philips_airpurifier",
   "name": "Philips AirPurifier (with CoAP)",
+  "version": "2021-03-07",
   "documentation": "https://github.com/betaboon/philips-airpurifier",
   "dependencies": [],
   "codeowners": ["@betaboon"],


### PR DESCRIPTION
Home Assistant now requires versioning for custom integrations.
https://developers.home-assistant.io/docs/creating_integration_manifest/

First version set ahead to 0.3.7 instead of 0.3.6 which is the latest release tag. Maybe you would like to create a new release, also reflecting the other great changes that happened after the fork.

closes #17 