### PR TITLE
More complete README including services and attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ source aioairctrl-shell.sh
 aioairctrl --host $DEVICE_IP status --json
 ```
 
-## Debugging
+## Debugging:
 
 To aquire debug-logs, add the following to your `configuration.yaml`:
 

--- a/README.md
+++ b/README.md
@@ -103,3 +103,122 @@ logger:
 ```
 
 logs should now be available in `home-assistant.log`
+
+
+## Usage:
+
+The integration provides `fan` entities for your devices which are [documented here](https://www.home-assistant.io/integrations/fan/).
+
+### Services:
+
+`philips_airpurifier` registers the following services in addition to the standard `fan`services:
+
+#### Turn the child lock on
+
+```yaml
+service: set_child_lock_on
+data:
+  entity_id: fan.ac2729_bedroom
+```
+
+#### Turn the child lock off
+
+```yaml
+service: set_child_lock_off
+data:
+  entity_id: fan.ac2729_bedroom
+```
+
+#### Turn the display backlight on
+
+```yaml
+service: set_display_backlight_on
+data:
+  entity_id: fan.ac2729_bedroom
+```
+
+#### Turn the display backlight off
+
+```yaml
+service: set_display_backlight_off
+data:
+  entity_id: fan.ac2729_bedroom
+```
+
+#### Set the light brightness
+
+```yaml
+service: set_light_brightness
+data:
+  entity_id: fan.ac2729_bedroom
+  brightness: 50
+```
+
+Brightness can take values between 0 and 100
+
+#### Set function of the device
+
+```yaml
+service: set_function
+data:
+  entity_id: fan.ac2729_bedroom
+  function: purification
+```
+
+This only applies to devices which offer purification and humidification. The `function` can take the values of `purification` or `purification_humidification`.
+
+#### Set humidity target
+
+```yaml
+service: set_humidity_target
+data:
+  entity_id: fan.ac2729_bedroom
+  humidity_target: 50
+```
+
+This only applies to devices which offer humidification. The `humidity_target` can take the values of `40`, `50`, `60`, or `70`.
+
+
+### Attributes
+
+The available attributes depend on the model. The following list gives an overview:
+
+| attribute |content | example |
+|---|---|---|
+| preset_modes: | Available operating modes of current device | `1`, `2`, `3`, `allergen`, `auto`, `night`, `turbo` |
+| preset_mode: | State of operating mode | auto |
+| name: | Name of the device | bedroom |
+| type: | Configured model | AC2729 |
+| model_id: | Philips model ID | AC2729/10 |
+| product_id: | Philips product ID | 85bc26fae62611e8a1e3061302926720 |
+| device_id: | Philips device ID | 3c84c6c8123311ebb1ae8e3584d00715 |
+| software_version: | Installed software version on device | 0.2.1 |
+| wifi_version: | Installed WIFI version on device | AWS_Philips_AIR@62.1 |
+| error_code: | Philips error code | 49408 |
+| error: | Error in clear text | no water |
+| child_lock: | State of child lock setting | false |
+| light_brightness: | State of brightness level | 50 |
+| display_backlight: | State of display backlight | false |
+| preferred_index: | State of preferred air quality index | `PM2.5`, `IAI` |
+| filter_pre_remaining: | Time until pre-filter needs cleaning in readable text | 10 days, 23:00:00 |
+| filter_pre_remaining_raw: | Time until pre-filter needs cleaning in hours | 263 |
+| filter_hepa_type: | Type of installed HEPA filter | A3 |
+| filter_hepa_remaining: | Time until HEPA filter needs replacement in readable text | 47 days, 14:00:00 |
+| filter_hepa_remaining_raw: | Time until HEPA filter needs replacement in hours | 1142 |
+| filter_active_carbon_type: | Type of installed active carbon filter | C7 |
+| filter_active_carbon_remaining: | Time until active carbon filter needs replacement in readable text | 47 days, 14:00:00 |
+| filter_active_carbon_remaining_raw: | Time until active carbon filter needs replacement in hours | 1142 |
+| runtime: | Time the device is running in readable text | 9 days, 10:44:41 |
+| air_quality_index: | State of Air Quality Index | 4 |
+| indoor_allergen_index: | State of Indoor Allergen Index | 2 |
+| pm25: | State of PM2.5 measurement | 8 |
+| filter_wick_remaining: | Time until wick filter needs clearning in readable text | 47 days, 14:00:00 |
+| filter_wick_remaining_raw: | Time until wick filter needs cleaning in hours | 1142 |
+| function: | State of operating function | Purification
+| humidity: | State of humidity in percent | 40 |
+| humidity_target: | Set of target humidity in percent | 50 |
+| temperature: | State of temperature in degrees Celsius | 20 |
+| water_level: | State of water level in tank in percent | 50 |
+| friendly_name: | Configured name for device | Bedroom |
+| icon: | Configured icon | pap:fan_speed_button |
+| supported_features: | Supported features | 8 |

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg?style=for-the-badge)](https://github.com/custom-components/hacs)
+[![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg?style=for-the-badge)](https://github.com/custom-components/hacs)
 
 This is a `Local Push` integration for Philips airpurifiers.
 Currently only encrypted-CoAP is implemented.


### PR DESCRIPTION
Questions by users show that available services beyond the standard `fan` services are not necessarily obvious. A more complete README file can give an easy overview also for unexperienced users.

The HACS badge has been changed to `custom` as this integration is not listed in the `default` directory of HACS.